### PR TITLE
Attempt to Reproduce gazelle issue

### DIFF
--- a/examples/build_file_generation/BUILD.bazel
+++ b/examples/build_file_generation/BUILD.bazel
@@ -18,6 +18,8 @@ compile_pip_requirements(
     requirements_windows = "requirements_windows.txt",
 )
 
+# gazelle:python_generation_mode file
+
 # This repository rule fetches the metadata for python packages we
 # depend on. That data is required for the gazelle_python_manifest
 # rule to update our manifest file.
@@ -57,47 +59,21 @@ gazelle(
     gazelle = "@rules_python_gazelle_plugin//python:gazelle_binary",
 )
 
-# This rule is auto-generated and managed by Gazelle,
-# because it found the __init__.py file in this folder.
-# See: https://bazel.build/reference/be/python#py_library
 py_library(
-    name = "build_file_generation",
+    name = "__init__",
     srcs = ["__init__.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "//random_number_generator",
+        "//random_number_generator:generate_random_number",
         "@pip//flask",
         "@pip//sphinx",
     ],
 )
 
-# A py_binary is an executable Python program consisting of a collection of .py source files.
-# See: https://bazel.build/reference/be/python#py_binary
-#
-# This rule is auto-generated and managed by Gazelle,
-# because it found the __main__.py file in this folder.
-# This rule creates a target named //:build_file_generation_bin and you can use
-# bazel to run the target:
-# `bazel run //:build_file_generation_bin`
 py_binary(
     name = "build_file_generation_bin",
     srcs = ["__main__.py"],
     main = "__main__.py",
     visibility = ["//:__subpackages__"],
-    deps = [":build_file_generation"],
-)
-
-# A py_test is a Python unit test.
-# See: https://bazel.build/reference/be/python#py_test
-#
-# This rule is auto-generated and managed by Gazelle,
-# because it found the __test__.py file in this folder.
-# This rule creates a target named //:build_file_generation_test and you can use
-# bazel to run the target:
-# `bazel test //:build_file_generation_test`
-py_test(
-    name = "build_file_generation_test",
-    srcs = ["__test__.py"],
-    main = "__test__.py",
-    deps = [":build_file_generation"],
+    deps = [":__init__"],
 )

--- a/examples/build_file_generation/random_number_generator/BUILD.bazel
+++ b/examples/build_file_generation/random_number_generator/BUILD.bazel
@@ -25,3 +25,9 @@ py_binary(
     srcs = ["other_bin.py"],
     visibility = ["//:__subpackages__"],
 )
+
+py_binary(
+    name = "before_bin",
+    srcs = ["before_bin.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/examples/build_file_generation/random_number_generator/BUILD.bazel
+++ b/examples/build_file_generation/random_number_generator/BUILD.bazel
@@ -2,17 +2,13 @@ load("@rules_python//python:py_library.bzl", "py_library")
 load("@rules_python//python:py_test.bzl", "py_test")
 
 py_library(
-    name = "random_number_generator",
-    srcs = [
-        "__init__.py",
-        "generate_random_number.py",
-    ],
+    name = "__init__",
+    srcs = ["__init__.py"],
     visibility = ["//:__subpackages__"],
 )
 
-py_test(
-    name = "random_number_generator_test",
-    srcs = ["__test__.py"],
-    main = "__test__.py",
-    deps = [":random_number_generator"],
+py_library(
+    name = "generate_random_number",
+    srcs = ["generate_random_number.py"],
+    visibility = ["//:__subpackages__"],
 )

--- a/examples/build_file_generation/random_number_generator/BUILD.bazel
+++ b/examples/build_file_generation/random_number_generator/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_python//python:py_library.bzl", "py_library")
 load("@rules_python//python:py_test.bzl", "py_test")
 
@@ -10,5 +11,11 @@ py_library(
 py_library(
     name = "generate_random_number",
     srcs = ["generate_random_number.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_binary(
+    name = "example_bin",
+    srcs = ["example_bin.py"],
     visibility = ["//:__subpackages__"],
 )

--- a/examples/build_file_generation/random_number_generator/BUILD.bazel
+++ b/examples/build_file_generation/random_number_generator/BUILD.bazel
@@ -19,3 +19,9 @@ py_binary(
     srcs = ["example_bin.py"],
     visibility = ["//:__subpackages__"],
 )
+
+py_binary(
+    name = "other_bin",
+    srcs = ["other_bin.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/examples/build_file_generation/random_number_generator/before_bin.py
+++ b/examples/build_file_generation/random_number_generator/before_bin.py
@@ -1,0 +1,5 @@
+def main():
+    print('hi')
+
+if __name__ == '__main__':
+    main()

--- a/examples/build_file_generation/random_number_generator/example_bin.py
+++ b/examples/build_file_generation/random_number_generator/example_bin.py
@@ -1,0 +1,5 @@
+def main():
+    print('hi')
+
+if __name__ == '__main__':
+    main()

--- a/examples/build_file_generation/random_number_generator/other_bin.py
+++ b/examples/build_file_generation/random_number_generator/other_bin.py
@@ -1,0 +1,5 @@
+def main():
+    print('hi')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I'm attempting to reproduce the gazelle issue I'm seeing here https://github.com/bazelbuild/rules_python/issues/2670 with a much simpler case. I haven't had much luck adding different `py_binary` targets  ...

They seem to get added fine when they're this simple, I wonder what could be causing the failure.

See commits such as:
- https://github.com/michael-christen/rules_python/pull/1/commits/43495912efce413a7ba9b5734c4049ad13c9b4be
- https://github.com/michael-christen/rules_python/pull/1/commits/de745c25650eb0d52c3455e71f6b6d6d83032940
